### PR TITLE
add crop option for PDF format

### DIFF
--- a/drawio-batch.js
+++ b/drawio-batch.js
@@ -50,6 +50,8 @@ program
     'scales the output file size for pixel-based output formats', parseScale, 1.0)
   .option('-b --bounds <WxH>',
     'Fits the generated image into the specified bounds, preserves aspect ratio.', parseBounds, {width: 0, height: 0})
+  .option('-c --crop',
+    'Crops the generated image (only if pdf)')
   .option('-d --diagramId <diagramId>',
     'selects a specific diagram', parseInt, 0)
   .arguments('<input> <output>')
@@ -70,16 +72,22 @@ const puppeteer = require('puppeteer');
 
     await page.goto('file://' + __dirname + '/drawio/src/main/webapp/export3.html')
 
-    await page.evaluate(function (xml, format, bounds, scale, diagramId) {
+    await page.evaluate(function (xml, format, bounds, scale, crop, diagramId) {
+      let width = bounds.width;
+      let height = bounds.height;
+      if (crop && format === 'pdf') {
+        width=0
+        height=-1
+      }
       return render({
         xml: xml,
         format: format,
         scale: scale,
-        w: bounds.width,
-        h: bounds.height,
+        w: width,
+        h: height,
         from: diagramId,
       })
-    }, input, program.format, program.bounds, program.scale, program.diagramId)
+    }, input, program.format, program.bounds, program.scale, program.crop, program.diagramId)
 
     await page.waitForSelector('#LoadingComplete');
     var bounds = await page.mainFrame().$eval('#LoadingComplete', div => div.getAttribute('bounds'));


### PR DESCRIPTION
Added an option '-c' to add the ability to export a cropped version of PDF instead of the paginated. So it is now possible to export the draw as a whole one page PDF.

It's a little hack by setting negativ height that leads to skip pagination for PDF format in export3.html (line 231):
```js
// Handles PDF output where the output should match the page format if the page is visible
if (data.format == 'pdf' && xmlDoc.documentElement.getAttribute('page') == '1' && data.w == 0 && data.h == 0)
```